### PR TITLE
bumped snappy

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
     "memoize-cache": "^5.0.0"
   },
   "optionalDependencies": {
-    "snappy": "^5.0.4"
+    "snappy": "^6.0.4"
   }
 }


### PR DESCRIPTION
This PR is to address few node security vulnerabilities raised on snappy.

Vulnerabilities:
https://nodesecurity.io/advisories/566
https://nodesecurity.io/advisories/598
https://nodesecurity.io/advisories/77
https://nodesecurity.io/advisories/309
https://nodesecurity.io/advisories/535

The issue seems to resolve after this upgrade.